### PR TITLE
Add support to parallelism

### DIFF
--- a/FunctionsLibrary.R
+++ b/FunctionsLibrary.R
@@ -11,6 +11,11 @@ parseArgs <- function(){
     default=3,
     help="Number of breeding cycles")
 
+  parser$add_argument("-nC", "--nCores",
+    type="integer", 
+    default=1,
+    help="Number of cores to run the simulation (2 or higher activates parallelism)")
+
   parser$add_argument("-nr", "--nReps", 
     type="integer", 
     default=15,

--- a/FunctionsLibrary.R
+++ b/FunctionsLibrary.R
@@ -30,6 +30,11 @@ parseArgs <- function(){
     type="character",
     help="Directory to write simulation outputs. Default is created based on training model name and date/time")
 
+  parser$add_argument("-vt", "--verboseTime", 
+    default=FALSE,
+    action="store_true",
+    help="Print training times in the output")
+
   parser$parse_args() # Returns arguments
 }
 
@@ -183,7 +188,12 @@ getVariances <- function(variances){
 trainModel <- function(gen){
   TrainingGeno <<- pullSegSiteGeno(gens[[gen]])
   TrainingPheno <<- pheno(gens[[gen]])
+  if (args$verboseTime) {
+    print("training model...")
+    tic()
+  }
   source(fileTrain)
+  if (args$verboseTime) toc()
 }
 
 # Create directory name based on date and time

--- a/FunctionsLibrary.R
+++ b/FunctionsLibrary.R
@@ -196,9 +196,6 @@ getVariances <- function(variances){
 
 # use trainGen to retrain the model
 trainModel <- function(gen){
-  TrainingGeno <<- pullSegSiteGeno(gens[[gen]])
-  TrainingPheno <<- pheno(gens[[gen]])
-  
   if (args$verbose) tic()
   source(fileTrain)
   if (args$verbose) {

--- a/FunctionsLibrary.R
+++ b/FunctionsLibrary.R
@@ -35,10 +35,15 @@ parseArgs <- function(){
     type="character",
     help="Directory to write simulation outputs. Default is created based on training model name and date/time")
 
-  parser$add_argument("-vt", "--verboseTime", 
+  parser$add_argument("-v", "--verbose", 
     default=FALSE,
     action="store_true",
     help="Print training times in the output")
+
+  parser$add_argument("-ct", "--clusterType",
+    type="character",
+    default="fork",
+    help="Set type of cluster (psock or fork)")
 
   parser$parse_args() # Returns arguments
 }
@@ -193,12 +198,12 @@ getVariances <- function(variances){
 trainModel <- function(gen){
   TrainingGeno <<- pullSegSiteGeno(gens[[gen]])
   TrainingPheno <<- pheno(gens[[gen]])
-  if (args$verboseTime) {
-    print("training model...")
-    tic()
-  }
+  
+  if (args$verbose) tic()
   source(fileTrain)
-  if (args$verboseTime) toc()
+  if (args$verbose) {
+    cat("Training finished. "); toc()
+  }
 }
 
 # Create directory name based on date and time

--- a/FunctionsLibrary.R
+++ b/FunctionsLibrary.R
@@ -40,11 +40,6 @@ parseArgs <- function(){
     action="store_true",
     help="Print training times in the output")
 
-  parser$add_argument("-ct", "--clusterType",
-    type="character",
-    default="fork",
-    help="Set type of cluster (psock or fork)")
-
   parser$parse_args() # Returns arguments
 }
 

--- a/RF_RD.R
+++ b/RF_RD.R
@@ -18,7 +18,7 @@ control <- trainControl(method='repeatedcv',
 
 trainMethod <- "rf"
 if (nCores > 1){
-    print(paste("Creating", clusterType, "cluster with", nCores, "cores..."))
+    print(paste("Creating cluster with", nCores, "cores..."))
     cl <- makePSOCKcluster(nCores)
     registerDoParallel(cl)
     trainMethod <- "parRF"

--- a/RF_RD.R
+++ b/RF_RD.R
@@ -18,11 +18,8 @@ control <- trainControl(method='repeatedcv',
 
 trainMethod <- "rf"
 if (nCores > 1){
-    print(paste("Creating", clusterType, "cluster with", nCores-1, "cores..."))
-    if (clusterType == "fork")
-        cl <- makeForkCluster(nnodes = (nCores-1), outfile = "./clusterOutput.log")
-    else
-        cl <- makePSOCKcluster(nCores - 1)
+    print(paste("Creating", clusterType, "cluster with", nCores, "cores..."))
+    cl <- makePSOCKcluster(nCores)
     registerDoParallel(cl)
     trainMethod <- "parRF"
 }

--- a/RF_RD.R
+++ b/RF_RD.R
@@ -16,16 +16,9 @@ control <- trainControl(method='repeatedcv',
                         repeats=1,
                         search = "random")  
 
-trainMethod = "rf"
-if (nCores > 1){
-    print(paste("Creating cluster with", nCores-1, "cores..."))
-    cl <- makeForkCluster(nCores - 1)
-    registerDoParallel(cl)
-    trainMethod = "parRF"
-    print("Training in parallel...")
-}
-
 ##build model##
+
+print("Training...")
 
 rf_fit = train(ID1 ~ ., 
                data = trainingset, 
@@ -33,9 +26,6 @@ rf_fit = train(ID1 ~ .,
                tuneLength = 10,
                trControl=control) ## search a random tuning grid ##
 
-if (nCores > 1){
-    print("Training finished.")
-    stopCluster(cl)
-}
+print("Training finished.")
 
 ### This command takes about 90 minutes in an compute canada interactive session ###

--- a/RF_RD.R
+++ b/RF_RD.R
@@ -10,19 +10,32 @@ train_index <- sample(1:nrow(trainingdata), 0.75 * nrow(trainingdata))
 trainingset <- trainingdata[train_index, ]
 testingset <- trainingdata[-train_index, ]
 
-
 ## create cross validation strategy ##
 control <- trainControl(method='repeatedcv', 
                         number=5, ##will test 10 different values for mtry (number of variables for splitting) ##
                         repeats=1,
                         search = "random")  
 
+trainMethod = "rf"
+if (nCores > 1){
+    print(paste("Creating cluster with", nCores, "cores..."))
+    cl <- makePSOCKcluster(nCores - 1)
+    registerDoParallel(cl)
+    trainMethod = "parRF"
+    print("Training in parallel...")
+}
+
 ##build model##
 
 rf_fit = train(ID1 ~ ., 
                data = trainingset, 
-               method = "rf",
+               method = trainMethod,
                tuneLength = 10,
                trControl=control) ## search a random tuning grid ##
+
+if (nCores > 1){
+    print("Training finished.")
+    stopCluster(cl)
+}
 
 ### This command takes about 90 minutes in an compute canada interactive session ###

--- a/RF_RD.R
+++ b/RF_RD.R
@@ -16,6 +16,17 @@ control <- trainControl(method='repeatedcv',
                         repeats=1,
                         search = "random")  
 
+trainMethod <- "rf"
+if (nCores > 1){
+    print(paste("Creating", clusterType, "cluster with", nCores-1, "cores..."))
+    if (clusterType == "fork")
+        cl <- makeForkCluster(nnodes = (nCores-1), outfile = "./clusterOutput.log")
+    else
+        cl <- makePSOCKcluster(nCores - 1)
+    registerDoParallel(cl)
+    trainMethod <- "parRF"
+}
+
 ##build model##
 
 print("Training...")
@@ -27,5 +38,9 @@ rf_fit = train(ID1 ~ .,
                trControl=control) ## search a random tuning grid ##
 
 print("Training finished.")
+
+# deactivate cluster
+if (nCores > 1)
+    stopCluster(cl)
 
 ### This command takes about 90 minutes in an compute canada interactive session ###

--- a/RF_RD.R
+++ b/RF_RD.R
@@ -18,8 +18,8 @@ control <- trainControl(method='repeatedcv',
 
 trainMethod = "rf"
 if (nCores > 1){
-    print(paste("Creating cluster with", nCores, "cores..."))
-    cl <- makePSOCKcluster(nCores - 1)
+    print(paste("Creating cluster with", nCores-1, "cores..."))
+    cl <- makeForkCluster(nCores - 1)
     registerDoParallel(cl)
     trainMethod = "parRF"
     print("Training in parallel...")

--- a/RF_RD.R
+++ b/RF_RD.R
@@ -12,8 +12,8 @@ testingset <- trainingdata[-train_index, ]
 
 ## create cross validation strategy ##
 control <- trainControl(method='repeatedcv', 
-                        number=5, ##will test 10 different values for mtry (number of variables for splitting) ##
-                        repeats=1,
+                        number=10, ##will test 10 different values for mtry (number of variables for splitting) ##
+                        repeats=3,
                         search = "random")  
 
 trainMethod <- "rf"

--- a/RF_RD.R
+++ b/RF_RD.R
@@ -18,23 +18,21 @@ control <- trainControl(method='repeatedcv',
 
 trainMethod <- "rf"
 if (nCores > 1){
-    print(paste("Creating cluster with", nCores, "cores..."))
+    if (args$verbose) 
+        print(paste("Creating cluster with", nCores, "cores..."))
     cl <- makePSOCKcluster(nCores)
     registerDoParallel(cl)
     trainMethod <- "parRF"
 }
 
 ##build model##
-
-print("Training...")
+if (args$verbose) cat ("Training...\n")
 
 rf_fit = train(ID1 ~ ., 
                data = trainingset, 
                method = trainMethod,
                tuneLength = 10,
                trControl=control) ## search a random tuning grid ##
-
-print("Training finished.")
 
 # deactivate cluster
 if (nCores > 1)

--- a/RunSims.R
+++ b/RunSims.R
@@ -1,4 +1,5 @@
 library(argparse)
+library(tictoc)
 source("FunctionsLibrary.R")
 
 args <- parseArgs()
@@ -9,6 +10,7 @@ nModels = 7
 nReps = args$nReps
 nGen = 10
 nVar = 9
+nCores = 1
 
 model = args$model
 nCycles = args$nCycles

--- a/RunSims.R
+++ b/RunSims.R
@@ -16,8 +16,6 @@ model = args$model
 nCycles = args$nCycles
 trainGen = args$trainGen
 
-clusterType = args$clusterType
-
 ## Create model definitions
 source("DefineModelVariables.R")
 

--- a/RunSims.R
+++ b/RunSims.R
@@ -10,7 +10,7 @@ nModels = 7
 nReps = args$nReps
 nGen = 10
 nVar = 9
-nCores = 1
+nCores = args$nCores
 
 model = args$model
 nCycles = args$nCycles

--- a/RunSims.R
+++ b/RunSims.R
@@ -16,6 +16,8 @@ model = args$model
 nCycles = args$nCycles
 trainGen = args$trainGen
 
+clusterType = args$clusterType
+
 ## Create model definitions
 source("DefineModelVariables.R")
 

--- a/SimplifiedBreedingCyclePipeline.R
+++ b/SimplifiedBreedingCyclePipeline.R
@@ -10,19 +10,6 @@ library(foreach)
 library(import)
 library(doParallel)
 
-if (model == "rf"){
-  trainMethod <- "rf"
-  if (nCores > 1){
-      print(paste("Creating cluster with", nCores-1, "cores..."))
-      if (clusterType == "fork")
-        cl <- makeForkCluster(nCores - 1)
-      else
-        cl <- makePSOCKcluster(nCores - 1)
-      registerDoParallel(cl)
-      trainMethod <- "parRF"
-  }
-}
-
 gens <- list()
 
 #Create Results Matrices
@@ -235,7 +222,3 @@ for (cycle in 1:nCycles){
     alleles[[cycle]][[rep]] <- allelesMat
     bv_ebv[[cycle]][[rep]] <- bv_ebv_df
 }
-
-# deactivate cluster
-if (nCores > 1)
-    stopCluster(cl)

--- a/SimplifiedBreedingCyclePipeline.R
+++ b/SimplifiedBreedingCyclePipeline.R
@@ -10,6 +10,15 @@ library(foreach)
 library(import)
 library(doParallel)
 
+if (model == "rf"){
+  trainMethod <- "rf"
+  if (nCores > 1){
+      print(paste("Creating cluster with", nCores-1, "cores..."))
+      cl <- makeForkCluster(nCores - 1)
+      registerDoParallel(cl)
+      trainMethod <- "parRF"
+  }
+}
 
 gens <- list()
 
@@ -77,16 +86,6 @@ trainModel("PYT")
 EBV <- getEBV(gens$PYT) #get EBVs
 gens$PYT@ebv = EBV #set EBVs
 corMat[1,] = cor(bv(gens$PYT), ebv(gens$PYT)) #determine model performance
-
-if (model == "rf"){
-  trainMethod = "rf"
-  if (nCores > 1){
-      print(paste("Creating cluster with", nCores-1, "cores..."))
-      cl <- makeForkCluster(nCores - 1)
-      registerDoParallel(cl)
-      trainMethod = "parRF"
-  }
-}
 
 # NEW CYCLE
 for (cycle in 1:nCycles){

--- a/SimplifiedBreedingCyclePipeline.R
+++ b/SimplifiedBreedingCyclePipeline.R
@@ -78,6 +78,16 @@ EBV <- getEBV(gens$PYT) #get EBVs
 gens$PYT@ebv = EBV #set EBVs
 corMat[1,] = cor(bv(gens$PYT), ebv(gens$PYT)) #determine model performance
 
+if (model == "rf"){
+  trainMethod = "rf"
+  if (nCores > 1){
+      print(paste("Creating cluster with", nCores-1, "cores..."))
+      cl <- makeForkCluster(nCores - 1)
+      registerDoParallel(cl)
+      trainMethod = "parRF"
+  }
+}
+
 # NEW CYCLE
 for (cycle in 1:nCycles){
     ## select new parents from previous cycle PYTs
@@ -223,3 +233,7 @@ for (cycle in 1:nCycles){
     alleles[[cycle]][[rep]] <- allelesMat
     bv_ebv[[cycle]][[rep]] <- bv_ebv_df
 }
+
+# deactivate cluster
+if (nCores > 1)
+    stopCluster(cl)

--- a/SimplifiedBreedingCyclePipeline.R
+++ b/SimplifiedBreedingCyclePipeline.R
@@ -70,6 +70,8 @@ gvMat[1,] <- mean(gv(gens$PYT))
 varMat[1,] <- varG(gens$PYT)
 
 ## use PYTs as training data and GS Prediction Model
+TrainingGeno <- pullSegSiteGeno(gens$PYT)
+TrainingPheno <- pheno(gens$PYT)
 trainModel("PYT")
 
 # calculate EBVs of PYTs

--- a/SimplifiedBreedingCyclePipeline.R
+++ b/SimplifiedBreedingCyclePipeline.R
@@ -14,7 +14,10 @@ if (model == "rf"){
   trainMethod <- "rf"
   if (nCores > 1){
       print(paste("Creating cluster with", nCores-1, "cores..."))
-      cl <- makeForkCluster(nCores - 1)
+      if (clusterType == "fork")
+        cl <- makeForkCluster(nCores - 1)
+      else
+        cl <- makePSOCKcluster(nCores - 1)
       registerDoParallel(cl)
       trainMethod <- "parRF"
   }

--- a/SimplifiedBreedingCyclePipeline.R
+++ b/SimplifiedBreedingCyclePipeline.R
@@ -6,6 +6,9 @@ library(ranger)
 library(tidyverse)
 library(e1071)
 library(randomForest)
+library(foreach)
+library(import)
+library(doParallel)
 
 
 gens <- list()


### PR DESCRIPTION
Branch updates:
- Added support to parallelism in Random Forest model
  - Set the number of cores with `--nCores` argument
- Added `-v` or `--verbose` parameter to print timestamps and other checkpoints
- Sets `trainingGeno` and `trainingPheno` only once in the beginning. It's faster because the first training data is smaller . This will probably have to be changed later.